### PR TITLE
Update to swf-tree 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ description = "Adobe Flash / SWF preservation tools."
 [dependencies]
 avm1-parser = "0.2.0"
 avm1-tree = "0.2.1"
-swf-parser = "0.8.0"
-swf-tree = "0.8.0"
+swf-parser = "0.9.0"
+swf-tree = "0.9.0"
 svg = "0.5.12"
 image = "0.20.1"
 inflate = "0.4.4"
@@ -23,9 +23,6 @@ structopt = "0.3"
 [lib]
 doctest = false
 test = false
-
-[patch.'crates-io']
-swf-parser = { git = "https://github.com/LykenSol/swf-parser", branch = "flashback-hacks" }
 
 [workspace]
 members = [

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -17,7 +17,7 @@ version = "0.0.1"
 [dependencies]
 futures = "0.1.26"
 js-sys = "0.3.17"
-swf-parser = "0.8.0"
+swf-parser = "0.9.0"
 wasm-bindgen = "0.2.40"
 wasm-bindgen-futures = "0.3.17"
 
@@ -38,6 +38,3 @@ features = [
   'SvgScriptElement',
   'Window',
 ]
-
-[patch.'crates-io']
-swf-parser = { git = "https://github.com/LykenSol/swf-parser", branch = "flashback-hacks" }


### PR DESCRIPTION
This commit updates the SWF parser and type definitions to the version 0.9.

This version adds **complete support for the SWF spec**. It means that any valid file should now be parsed successfully. More improvements are planned to support invalid files. These changes were tested against Open Flash's test samples and the movies mentioned in https://github.com/LykenSol/flashback/pull/3#issuecomment-515109082.

- https://github.com/open-flash/swf-tree/blob/master/CHANGELOG.md#090-2019-10-17
- https://github.com/open-flash/swf-parser/blob/master/CHANGELOG.md#090-2019-10-17