### PR TITLE
Require CI success on stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,3 @@ script: cargo test --all
 branches:
   only:
   - master
-
-matrix:
-  allow_failures:
-  - rust: stable # TODO(eddyb) remove when 1.32 is released


### PR DESCRIPTION
This commit removes the `allow_failure` config for stable Rust. According to the comment it is no longer needed since the release of Rust 1.32.